### PR TITLE
Fix watching when HTML output does not exist yet

### DIFF
--- a/lib/slippery/rake_tasks.rb
+++ b/lib/slippery/rake_tasks.rb
@@ -88,7 +88,7 @@ module Slippery
             desc "watch #{name} for changes"
             WatchTask.new(name, [path.to_s, *files]) do
               dest = Tempfile.new("#{name}.html")
-              File.open("#{name}.html") { |src| FileUtils.copy_stream(src, dest) }
+              File.open("#{name}.html", 'w+') { |src| FileUtils.copy_stream(src, dest) }
               dest.close
               Rake::Task["#{@name}:build:#{name}"].execute
               puts "="*60


### PR DESCRIPTION
I stumbled upon a bug while working on #7: the watch task crashed when the HTML output didn't exist.
