### PR TITLE
Bump listen to 3.0

### DIFF
--- a/slippery.gemspec
+++ b/slippery.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'kramdown'     , '~> 1.1'
   gem.add_runtime_dependency 'hexp-kramdown', '> 0'
   gem.add_runtime_dependency 'rake'         , '~> 10.1'
-  gem.add_runtime_dependency 'listen'       , '~> 2.7'
+  gem.add_runtime_dependency 'listen'       , '~> 3.0'
   gem.add_runtime_dependency 'concord'      , '~> 0.1.4'
   gem.add_runtime_dependency 'asset_packer' , '~> 0.3.0'
 


### PR DESCRIPTION
I'm experiencing the situation where Listen 2.x stops listening to file watch events after the first couple file changes. On Ctrl + C, I see an `Celluloid::DeadActorError: attempted to call a dead actor`

Listen 3.0 _seems_ to be working more reliably.
